### PR TITLE
fix: Use ENTRYPOINT instead of  CMD to receive os.Signal correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ CMD dlv -l :40000 --headless=true --api-version=2 test -test.v ./...
 
 FROM ghcr.io/edwarnicke/govpp/vpp:${VPP_VERSION} as runtime
 COPY --from=build /bin/cmd-nse-icmp-responder-vpp /bin/cmd-nse-icmp-responder-vpp
-CMD /bin/cmd-nse-icmp-responder-vpp
+ENTRYPOINT [ "/bin/cmd-nse-icmp-responder-vpp" ] 


### PR DESCRIPTION
**Signed-off-by:** Denis Tingaikin <denis.tingajkin@xored.com>