### PR TITLE
qfix: add missed registry/sendfd additional functionality

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,7 @@ linters-settings:
   dupl:
     threshold: 150
   funlen:
-    Lines: 190
+    Lines: 200
     Statements: 90
   goconst:
     min-len: 2

--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/ipam/point2pointipam"
 	_ "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
+	_ "github.com/networkservicemesh/sdk/pkg/registry/common/sendfd"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/debug"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/log"

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/ipam/point2pointipam"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
+	registrysendfd "github.com/networkservicemesh/sdk/pkg/registry/common/sendfd"
 	"github.com/networkservicemesh/sdk/pkg/tools/debug"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
@@ -251,7 +252,14 @@ func main() {
 		}
 	}
 
-	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, &config.ConnectTo, registryclient.WithDialOptions(clientOptions...))
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(
+		ctx,
+		&config.ConnectTo,
+		registryclient.WithDialOptions(clientOptions...),
+		registryclient.WithNSEAdditionalFunctionality(
+			registrysendfd.NewNetworkServiceEndpointRegistryClient(),
+		),
+	)
 	nse := &registryapi.NetworkServiceEndpoint{
 		Name:                 config.Name,
 		NetworkServiceNames:  config.ServiceNames,


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>


## Motivation

We've removed `sendfd` from default registry/chains because NSM can be used in non-k8s systems. Now we need to add for each k8s nse app `sendfd` as additional functionality 