### PR TITLE
Add interface names into NSM metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ import (
 	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/connectioncontext"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/mechanisms/memif"
+	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/stats"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/tag"
 	"github.com/networkservicemesh/sdk-vpp/pkg/networkservice/up"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
@@ -198,6 +199,7 @@ func main() {
 		endpoint.WithAuthorizeServer(authorize.NewServer()),
 		endpoint.WithAdditionalFunctionality(
 			ipamChain,
+			stats.NewServer(ctx, vppConn, stats.InterfaceOnly(true)),
 			mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
 				memif.MECHANISM: chain.NewNetworkServiceServer(
 					sendfd.NewServer(),


### PR DESCRIPTION
Task: https://github.com/networkservicemesh/sdk-vpp/issues/768

Add interface details for NSE:
![metrixNew drawio (1)](https://github.com/networkservicemesh/cmd-nsc/assets/10182393/eb496fec-1833-4c26-adf9-33eceaed5b2f)